### PR TITLE
Set up handling for logging/tracing verbosity via commandline flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-verbosity-flag"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e2b6c3dcdb73299f48ae05b294da14e2f560b3ed2c09e742269eb1b22af231"
+dependencies = [
+ "clap 4.1.4",
+ "log",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +594,7 @@ name = "lustre"
 version = "0.2.2"
 dependencies = [
  "clap 4.1.4",
+ "clap-verbosity-flag",
  "criterion",
  "glam",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["rendering"]
 
 [dependencies]
 clap = { version = "4.1", features = ["derive", "wrap_help"] }
+clap-verbosity-flag = "2.0.0"
 glam = { version = "0.22", features = ["debug-glam-assert", "rand"] }
 image = { version = "0.24", default-features = false, features = [
     "jpeg",

--- a/benches/tree.rs
+++ b/benches/tree.rs
@@ -132,6 +132,7 @@ fn bench_full_scenes(c: &mut Criterion) {
                 bounce_depth: 50,
                 scene,
                 seed: Some(0),
+                verbosity: lustre::cli::Verbosity::new(0, 1),
             },
             &mut rng,
         );

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,8 @@
 
 use clap::Parser;
 
+pub use clap_verbosity_flag::Verbosity;
+
 use crate::scenes::SceneType;
 
 /// Parses the commandline arguments into an [Arguments] struct
@@ -64,6 +66,9 @@ pub struct Arguments {
     /// The seed used for psuedorandom number generation
     #[clap(long)]
     pub seed: Option<u64>,
+
+    #[clap(flatten)]
+    pub verbosity: self::Verbosity,
 }
 
 /// Checks whether the given integer value is greater than 0

--- a/src/render.rs
+++ b/src/render.rs
@@ -32,6 +32,8 @@ pub struct RenderContext {
     geometry: std::sync::Arc<dyn Hittable>,
     /// Whether or not to output HDR images
     output_hdr: bool,
+    /// The level of output verbosity
+    verbosity: crate::cli::Verbosity,
 }
 
 impl RenderContext {
@@ -58,6 +60,7 @@ impl RenderContext {
             bounce_depth: args.bounce_depth,
             samples_per_pixel: args.samples_per_pixel,
             output_hdr,
+            verbosity: args.verbosity.clone(),
         }
     }
 
@@ -89,6 +92,11 @@ impl RenderContext {
     pub fn render(&self) -> DynamicImage {
         let progress_bar = get_progressbar((self.image_height * self.image_width) as u64)
             .with_prefix("Generating pixels");
+
+        // stops the progress bar from outputting anything
+        if self.verbosity.is_silent() {
+            progress_bar.set_draw_target(indicatif::ProgressDrawTarget::hidden());
+        }
 
         // Allocate image buffer
         // default to f32 to keep hdr data until write time

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -17,5 +17,5 @@ pub fn get_progressbar(len: u64) -> ProgressBar {
             "[{elapsed_precise}] {spinner} {prefix} {human_pos:>7}/{human_len:7} ({percent}%) {msg}",
         )
         .unwrap(),
-    ).with_finish(ProgressFinish::WithMessage(std::borrow::Cow::Owned("Done!".to_string())))
+    ).with_finish(ProgressFinish::WithMessage("Done!".into()))
 }


### PR DESCRIPTION
- the command line parser supports `-q, --quiet` and `-v, --verbose` options via the [`clap_verbosity_flag`](https://crates.io/crates/clap-verbosity-flag) crate
- the existing benchmarks for full renderings use the verbosity setup to quiet the usual rendering cli output